### PR TITLE
Quick fix to read and store timezones in Grounds

### DIFF
--- a/lib/sportdb/models/ground.rb
+++ b/lib/sportdb/models/ground.rb
@@ -42,11 +42,14 @@ class Ground < ActiveRecord::Base
         logger.info "  found clubs line #{value}; skipping for now"
       elsif value =~ /^(?:[a-z]{2}\.)?wikipedia:/  # assume it's wikipedia e.g. [es.]wikipedia:
         logger.info "  found wikipedia line #{value}; skipping for now"
+      elsif value =~ /GMT[+-][0-9]/ # dirrty hack for time zones
+        logger.info "  found time zone #{value}"
+        new_attributes[ :timezone ] = value
       else
         logger.info "  found city >#{value}< for ground >#{new_attributes[ :key ]}<"
 
         city_title = value.dup   # remember for auto-add city
-        
+
         ## todo: assume title2 ??
         ## assume title2 if title2 is empty (not already in use)
         ##  and if it title2 contains at least two letter e.g. [a-zA-Z].*[a-zA-Z]
@@ -72,7 +75,7 @@ class Ground < ActiveRecord::Base
     #### try to auto-add city
 
     if city_title.present?
-      
+
       ### todo/fix: strip city_title subtitles e.g. Hamburg (Hafen) becomes Hamburg etc.
       city_values = [city_title]
       city_attributes = {
@@ -97,4 +100,3 @@ end # class Ground
 
   end # module Model
 end # module SportDb
-

--- a/lib/sportdb/schema.rb
+++ b/lib/sportdb/schema.rb
@@ -30,22 +30,23 @@ add_index :teams, :key, unique: true
 
 create_table :grounds do |t|
   t.string     :key,      null: false   # import/export key
-  t.string     :title,    null: false 
+  t.string     :title,    null: false
   t.string     :synonyms   # comma separated list of synonyms
-  
+
   t.references :country,  null: false
   t.references :city     # todo: make city required ???
 
   t.integer :since     # founding year
   t.integer :capacity  # attentence capacity e.g. 10_000 or 50_000 etc.
   t.string  :address
+  t.string  :timezone
 
 
   ### fix/todo: add since/founded/opened/build attrib  eg. 2011 or 1987
   ##   - add capacity e.g. 40_000
   ##  fix: add address !!!! etc
 
-  ## add region ??? or just use region from city ?? 
+  ## add region ??? or just use region from city ??
 
   t.timestamps
 end
@@ -80,7 +81,7 @@ create_table :goals do |t|
   t.integer   :offset    # e.g. 45' +3 or 90' +2
   t.integer   :score1
   t.integer   :score2
-  
+
   ## type of goal (penalty, owngoal)
   t.boolean   :penalty,   null: false, default: false
   t.boolean   :owngoal,   null: false, default: false  # de: Eigentor -> # todo: find better name?
@@ -234,7 +235,7 @@ create_table :games do |t|
   t.references :prev_game
 
   t.integer    :winner      # 1,2,0,nil  calculate on save  - "real" winner (after 90 or extra time or penalty, aggregated first+second leg?)
-  t.integer    :winner90    # 1,2,0,nil  calculate on save  - winner after 90 mins (or regugular play time depending on sport - add alias or find  a better name!) 
+  t.integer    :winner90    # 1,2,0,nil  calculate on save  - winner after 90 mins (or regugular play time depending on sport - add alias or find  a better name!)
 
   t.timestamps
 end
@@ -292,7 +293,7 @@ create_table :leagues do |t|  ## also for cups/conferences/tournaments/world ser
   t.string     :key,   null: false
   t.string     :title, null: false     # e.g. Premier League, Deutsche Bundesliga, World Cup, Champions League, etc.
   t.references :country   ##  optional for now ,   :null => false   ### todo: create "virtual" country for international leagues e.g. use int? or world (ww?)/europe (eu)/etc. similar? already taken??
- 
+
   ## fix: rename to :clubs from :club
   t.boolean    :club,          null: false, default: false  # club teams or national teams?
   ## todo: add t.boolean  :national flag? for national teams?


### PR DESCRIPTION
Hi Gerald,

the time zones can now be stored in the grounds table. 
- changed schema.rb for the table definition
- changed model/ground.rb to store time zone
- changed readers/game to parse the line (in a non sophisticated way, I simply don't understand your TextUtils stuff ;-))

Cheers,
Martin
