### PR TITLE
Use String#gsub with a Hash as the replacement

### DIFF
--- a/alphabets/benchmark/unaccent.rb
+++ b/alphabets/benchmark/unaccent.rb
@@ -18,12 +18,12 @@ UNACCENT = {
   'Ú'=>'U',  'ú'=>'u',
 }
 
-UNACCENT_DE = UNACCENT.merge {
+UNACCENT_DE = UNACCENT.merge({
   'Ä'=>'AE',  'ä'=>'ae',
   'Ö'=>'OE',  'ö'=>'oe',
               'ß'=>'ss',
   'Ü'=>'UE',  'ü'=>'ue',
-}
+})
 
 
 def unaccent_each_char( text, mapping )
@@ -99,11 +99,14 @@ def unaccent_gsub_v2( text, mapping )
   end
 end
 
+def unaccent_gsub_v3( text, mapping )
+  text.gsub( NON_ALPHA_CHAR_REGEX, mapping )
+end
 
 
 def benchmark( str, mapping, n: 20_000 )
   puts "text=>#{str}<, n=#{n}:"
-  Benchmark.bm do |benchmark|
+  Benchmark.bm(20) do |benchmark|
     benchmark.report( 'each_char' ) do
       n.times { unaccent_each_char( str, mapping ) }
     end
@@ -126,6 +129,10 @@ def benchmark( str, mapping, n: 20_000 )
 
     benchmark.report( 'gsub_v2' ) do
       n.times { unaccent_gsub_v2( str, mapping ) }
+    end
+
+    benchmark.report( 'gsub_v3' ) do
+      n.times { unaccent_gsub_v3( str, mapping ) }
     end
 
     benchmark.report( 'scan' ) do
@@ -168,6 +175,9 @@ pp unaccent_gsub( str1, UNACCENT_DE )
 
 pp unaccent_gsub_v2( str1, UNACCENT )
 pp unaccent_gsub_v2( str1, UNACCENT_DE )
+
+pp unaccent_gsub_v3( str1, UNACCENT )
+pp unaccent_gsub_v3( str1, UNACCENT_DE )
 
 pp unaccent_scan( str1, UNACCENT )
 pp unaccent_scan( str1, UNACCENT_DE )


### PR DESCRIPTION
You missed that `gsub` can take a Hash as its second argument.
```
                           user     system      total        real
each_char              1.580000   0.020000   1.600000 (  1.633651)
each_char_v2           1.350000   0.010000   1.360000 (  1.413720)
each_char_reduce       1.770000   0.020000   1.790000 (  1.846817)
each_char_reduce_v2    1.500000   0.020000   1.520000 (  1.549961)
gsub                   1.380000   0.010000   1.390000 (  1.422130)
gsub_v2                1.150000   0.010000   1.160000 (  1.181604)
gsub_v3                0.960000   0.020000   0.980000 (  1.001596)
scan                   2.360000   0.020000   2.380000 (  2.436495)
```